### PR TITLE
fix: Remove capitalization of "mac"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 pkg
+Gemfile.lock

--- a/capitalize_names.gemspec
+++ b/capitalize_names.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.0'
   s.add_runtime_dependency "activesupport", [">= 3"]
-  s.add_development_dependency 'minitest', ' ~>5.8.4'
+  s.add_development_dependency 'minitest'
+  s.add_development_dependency 'rake'
   s.homepage    = 'http://github.com/infiton/capitalize-names'
   s.license     = 'MIT'
 end

--- a/lib/capitalize_names/capitalizer.rb
+++ b/lib/capitalize_names/capitalizer.rb
@@ -4,7 +4,7 @@ module CapitalizeNames
 
     HYPHEN = /(\s*-\s*)/
 
-    MC = /^Mc(\w)(?=\w)/i 
+    MC = /^Mc(\w)(?=\w)/i
     MAC = /^Mac(\w)(?=\w)/i
     O_APOSTROPHE = /^O'(\w)(?=\w)/i
 
@@ -70,7 +70,6 @@ module CapitalizeNames
           w.mb_chars.capitalize.to_str 
         }.map{ |w|
           w.gsub(MC) { "Mc#{$1.upcase}" }\
-           .gsub(MAC) { "Mac#{$1.upcase}" }\
            .gsub(O_APOSTROPHE) { "O'#{$1.upcase}" }
         }
 

--- a/lib/capitalize_names/capitalizer.rb
+++ b/lib/capitalize_names/capitalizer.rb
@@ -5,7 +5,6 @@ module CapitalizeNames
     HYPHEN = /(\s*-\s*)/
 
     MC = /^Mc(\w)(?=\w)/i
-    MAC = /^Mac(\w)(?=\w)/i
     O_APOSTROPHE = /^O'(\w)(?=\w)/i
 
     def initialize(name)
@@ -66,8 +65,8 @@ module CapitalizeNames
           hyphens << [_start, _end, _value]
         end
 
-        _name = _name.split.map{ |w| 
-          w.mb_chars.capitalize.to_str 
+        _name = _name.split.map{ |w|
+          w.mb_chars.capitalize.to_str
         }.map{ |w|
           w.gsub(MC) { "Mc#{$1.upcase}" }\
            .gsub(O_APOSTROPHE) { "O'#{$1.upcase}" }
@@ -82,7 +81,7 @@ module CapitalizeNames
             _name = _name[0..._start] << _value << (_name[_start+1..-1] || "")
           end
         end
-            
+
         _name = _name.gsub("Van ", "van ").gsub("De ", "de ").gsub("Dit ", "dit ")
         _name << " "
 

--- a/test/test_capitalize_names.rb
+++ b/test/test_capitalize_names.rb
@@ -8,8 +8,6 @@ class CapitalizeNamesTest < Minitest::Test
     assert_equal "Clarke", CapitalizeNames.capitalize("cLaRKe") #basic mix
     assert_equal "McElroy", CapitalizeNames.capitalize("MCELROY") #mc
     assert_equal "Mc", CapitalizeNames.capitalize("MC") #mc
-    assert_equal "MacElvany", CapitalizeNames.capitalize("macelvany") #mac
-    assert_equal "Mac", CapitalizeNames.capitalize("mac") #mac
     assert_equal "O'Neill", CapitalizeNames.capitalize("O'NEILL") # O'
     assert_equal "VanWinkle", CapitalizeNames.capitalize("VANWINKLE") #from surnames list
     assert_equal "Rip VanWinkle", CapitalizeNames.capitalize("rip VANWINKLE") #from surnames list
@@ -19,10 +17,8 @@ class CapitalizeNamesTest < Minitest::Test
     assert_equal "Johnson-Smith", CapitalizeNames.capitalize("johnson-smith") #hypenated
     assert_equal "Sullivan", CapitalizeNames.capitalize("SULLIVAN") # IV in the middle
     assert_equal "Bumcorn", CapitalizeNames.capitalize("bumcorn") # MC in the middle
-    assert_equal "Tomacron", CapitalizeNames.capitalize("TOMACRON") # MAC in the middle
     assert_equal "Treo'las", CapitalizeNames.capitalize("treo'las") # O' in the middle
     assert_equal "Ronald McDonald", CapitalizeNames.capitalize("ronald mcdonald")
-    assert_equal "Sarah MacDonald", CapitalizeNames.capitalize("Sarah macdonald")
     assert_equal "Réne", CapitalizeNames.capitalize("RÉNE") # accents
     assert_equal "Élise", CapitalizeNames.capitalize("éLiSE") #accents
     assert_equal "Denise", CapitalizeNames.capitalize("DENISE")


### PR DESCRIPTION
There are legitimate names beginning with mac that don't require the subsequent characters to be capitalized. For example in [Faker](https://github.com/faker-ruby/faker/blob/master/lib/locales/en/name.yml) we have Machelle, Macie, Mackenzie, Macy.

This removes mac from the capitalization logic. We could make this more extensible / configurable in the future if there's a need.

I'm not entirely sure why some of the Leads in our db (e.g. Mackey) don't seem to suffer from the wrong capitalization, we might be skipping validations in some code paths.