### PR TITLE
fix: Remove VI as suffix as it is a valid Vietnamese name

### DIFF
--- a/lib/capitalize_names/suffixes.rb
+++ b/lib/capitalize_names/suffixes.rb
@@ -6,7 +6,7 @@ module CapitalizeNames
     "(III)",
     "IV",
     "(IV)",
-    "VI",
+    # "VI", this is a valid vietnamese name
     "(VI)",
     "VII",
     "(VII)",

--- a/test/test_capitalize_names.rb
+++ b/test/test_capitalize_names.rb
@@ -26,6 +26,7 @@ class CapitalizeNamesTest < Minitest::Test
     assert_equal "-Gleny Mejia-", CapitalizeNames.capitalize("-Gleny Mejia-")
     assert_equal "Cinnamon Ballantye - Clarke", CapitalizeNames.capitalize("Cinnamon Ballantye - Clarke")
     assert_equal " - Cinnamon Ballantye - Clarke-van Buren- ", CapitalizeNames.capitalize(" - CinnAMon BaLLantye - Clarke-VAN BUREN- ")
+    assert_equal "Vi", CapitalizeNames.capitalize("vi") # single suffix shouldn't be all-caps
   end
 
   def test_invalid_name

--- a/test/test_capitalize_names.rb
+++ b/test/test_capitalize_names.rb
@@ -26,7 +26,7 @@ class CapitalizeNamesTest < Minitest::Test
     assert_equal "-Gleny Mejia-", CapitalizeNames.capitalize("-Gleny Mejia-")
     assert_equal "Cinnamon Ballantye - Clarke", CapitalizeNames.capitalize("Cinnamon Ballantye - Clarke")
     assert_equal " - Cinnamon Ballantye - Clarke-van Buren- ", CapitalizeNames.capitalize(" - CinnAMon BaLLantye - Clarke-VAN BUREN- ")
-    assert_equal "Vi", CapitalizeNames.capitalize("vi") # single suffix shouldn't be all-caps
+    assert_equal "Vi", CapitalizeNames.capitalize("vi") # a suffix-like but also a valid vietnamese name
   end
 
   def test_invalid_name


### PR DESCRIPTION
for unblocking of https://6si.slack.com/archives/C0301T14QDV/p1706132992206099

I think users should be responsible for name capitalizations during the contact enrolment step and user creation, maybe we should remove this dependency? It has caused random flaky tests and ES tickets in the past

don't know if there are other "VI"s, might open up another can of worms 